### PR TITLE
A few more tweaks.

### DIFF
--- a/luthier/src/main/java/com/yahoo/bard/webservice/config/luthier/LuthierIndustrialPark.java
+++ b/luthier/src/main/java/com/yahoo/bard/webservice/config/luthier/LuthierIndustrialPark.java
@@ -158,8 +158,8 @@ public class LuthierIndustrialPark implements ConfigurationLoader {
         /**
          * Constructor.
          *
-         * @param resourceDictionaries a class that contains resource dictionaries including
-         *                             PhysicalTableDictionary, DimensionDictionary, etc.
+         * @param resourceDictionaries  a class that contains resource dictionaries including
+         * PhysicalTableDictionary, DimensionDictionary, etc.
          */
         public Builder(ResourceDictionaries resourceDictionaries) {
             this.resourceDictionaries = resourceDictionaries;
@@ -180,9 +180,13 @@ public class LuthierIndustrialPark implements ConfigurationLoader {
         }
 
         /**
-         * specifies dimension factories when initializing a builder.
+         * Registers named dimension factories with the Industrial Park Builder.
+         * <p>
+         * There should be one factory per type of dimension used in the config
          *
-         * @param factories a factory of a specific dimension
+         * @param factories  A mapping from a dimension type identifier used in the config
+         * to a factory that builds Dimensions of that type
+         *
          * @return the builder object
          */
         public Builder withDimensionFactories(Map<String, Factory<Dimension>> factories) {
@@ -191,10 +195,14 @@ public class LuthierIndustrialPark implements ConfigurationLoader {
         }
 
         /**
-         * specifies a dimension when initializing a builder.
+         * Registers a named dimension factory with the Industrial Park Builder.
+         * <p>
+         * There should be one factory per type of dimension used in the config
          *
-         * @param name the name of the factory
-         * @param factory factory to supply
+         * @param name  The identifier used in the configuration to identify the type of
+         * dimension built by this factory
+         * @param factory  A factory that builds Dimensions of the type named by {@code name}
+         *
          * @return the builder object
          */
         public Builder withDimensionFactory(String name, Factory<Dimension> factory) {
@@ -203,9 +211,9 @@ public class LuthierIndustrialPark implements ConfigurationLoader {
         }
 
         /**
-         * build function to construct an instance of LuthierIndustrialPark.
+         * Builds a LuthierIndustrialPark.
          *
-         * @return the LuthierIndustrialPark with the specified resourceDictionaries and dimensionFactories
+         * @return the LuthierIndustrialPark with the specified resourceDictionaries and factories
          */
         public LuthierIndustrialPark build() {
             return new LuthierIndustrialPark(resourceDictionaries, new LinkedHashMap<>(dimensionFactories));

--- a/luthier/src/main/java/com/yahoo/bard/webservice/config/luthier/LuthierValidationUtils.java
+++ b/luthier/src/main/java/com/yahoo/bard/webservice/config/luthier/LuthierValidationUtils.java
@@ -1,0 +1,36 @@
+// Copyright 2019, Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.config.luthier;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Contains a collection of static methods to make it easier to perform configuration validation.
+ */
+public class LuthierValidationUtils {
+
+    public static final String MISSING_FIELD_ERROR = "%s '%s': Missing required field '%s'";
+
+    /**
+     * Validates that the given field actually exists. If it doesn't, throws a useful error message.
+     *
+     * @param fieldValue The value to check for existence
+     * @param configEntityType  The type of the config entity whose field we're validating
+     * @param configEntityName The name of the config entity we're currently building
+     * @param fieldName  The name of the field whose value we're validating
+     */
+    public static void validateField(
+            JsonNode fieldValue,
+            String configEntityType,
+            String configEntityName,
+            String fieldName
+    ) {
+        if (fieldValue == null) {
+            throw new LuthierFactoryException(String.format(MISSING_FIELD_ERROR, configEntityName, fieldName));
+        }
+    }
+
+    /** Just a bunch of static functions. **/
+    private LuthierValidationUtils() {
+    }
+}

--- a/luthier/src/main/java/com/yahoo/bard/webservice/data/config/LuthierDimensionField.java
+++ b/luthier/src/main/java/com/yahoo/bard/webservice/data/config/LuthierDimensionField.java
@@ -20,9 +20,9 @@ public class LuthierDimensionField implements DimensionField {
     /**
      * Constructor.
      *
-     * @param camelName camelCased name of a dimensionField.
-     * @param description description of that dimensionField.
-     * @param tags A list of Strings that represents the tags of that field
+     * @param camelName  camelCased name of a dimensionField.
+     * @param description  description of that dimensionField.
+     * @param tags  A list of Strings that represents the tags of that field
      */
     public LuthierDimensionField(String camelName, String description, List<String> tags) {
         this.camelName = camelName;


### PR DESCRIPTION
-- Changes (hopefully improving) some JavaDoc, including fixing their
styling:
        a. When wrapping a `@param` description, the second line starts
            right underneath `@param`.
        b. There should be two spaces between the name of the param, and
            its description.

-- Includes the list of fields we know about for a dimension in the
`unknownDefaultField` error message. Keep in mind that customers may be
generating their dimension fields (or anything really) programatically,
so if we can include our view of the world (well, the pertinent bit) in
the error message, it'll go a long way to helping customers fix their
config.

-- Adds validation for every dimension field. Before, if a customer
forgot a field that we relied on, they'd get a *very* not helpful
`NullPointerException`. Now, we tell them which field is missing in
which dimension. Calling this method is before every field request in
every builtin factory will be less than ideal, and will become
unnecessary if/when we do the bean validation thing that @mclawhor
recommended, but that isn't here yet, and the config should be useable
even if we don't have time to do add bean validation anytime soon
(which is likely).